### PR TITLE
Status and Print Columns Added

### DIFF
--- a/api/v1/hogeye_types.go
+++ b/api/v1/hogeye_types.go
@@ -43,6 +43,11 @@ type HogEyeStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.status`,description="Will display one of [Watching, Redeploying, Terminating, Error]"
+// +kubebuilder:printcolumn:name="Resource Type",type=string,JSONPath=`.spec.queryResources`
+// +kubebuilder:printcolumn:name="Observed Namespace",type=string,JSONPath=`.spec.queryNamespace`
+// +kubebuilder:printcolumn:name="Age Threshold",type=string,JSONPath=`.spec.ageThreshold`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // HogEye is the Schema for the hogeyes API
 type HogEye struct {

--- a/api/v1/hogeye_types.go
+++ b/api/v1/hogeye_types.go
@@ -38,8 +38,7 @@ type HogEyeSpec struct {
 
 // HogEyeStatus defines the observed state of HogEye
 type HogEyeStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
+	Status string `json:"status,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1/hogeye_types.go
+++ b/api/v1/hogeye_types.go
@@ -44,9 +44,9 @@ type HogEyeStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.status`,description="Will display one of [Watching, Redeploying, Terminating, Error]"
-// +kubebuilder:printcolumn:name="Resource Type",type=string,JSONPath=`.spec.queryResources`
-// +kubebuilder:printcolumn:name="Observed Namespace",type=string,JSONPath=`.spec.queryNamespace`
-// +kubebuilder:printcolumn:name="Age Threshold",type=string,JSONPath=`.spec.ageThreshold`
+// +kubebuilder:printcolumn:name="Resource_Type",type=string,JSONPath=`.spec.queryResources`
+// +kubebuilder:printcolumn:name="Observed_Namespace",type=string,JSONPath=`.spec.queryNamespace`
+// +kubebuilder:printcolumn:name="Age_Threshold",type=string,JSONPath=`.spec.ageThreshold`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // HogEye is the Schema for the hogeyes API

--- a/api/v1/hogeye_types.go
+++ b/api/v1/hogeye_types.go
@@ -43,11 +43,11 @@ type HogEyeStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.status`,description="Will display one of [Watching, Redeploying, Terminating, Error]"
-// +kubebuilder:printcolumn:name="Resource_Type",type=string,JSONPath=`.spec.queryResources`
-// +kubebuilder:printcolumn:name="Observed_Namespace",type=string,JSONPath=`.spec.queryNamespace`
-// +kubebuilder:printcolumn:name="Age_Threshold",type=string,JSONPath=`.spec.ageThreshold`
-// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
+//+kubebuilder:printcolumn:name="Status",type=string,JSONPath=`.status.status`,description="Will display one of [Watching, Redeploying, Terminating, Error]"
+//+kubebuilder:printcolumn:name="Resource_Type",type=string,JSONPath=`.spec.queryResources`
+//+kubebuilder:printcolumn:name="Observed_Namespace",type=string,JSONPath=`.spec.queryNamespace`
+//+kubebuilder:printcolumn:name="Age_Threshold",type=string,JSONPath=`.spec.ageThreshold`
+//+kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // HogEye is the Schema for the hogeyes API
 type HogEye struct {

--- a/config/crd/bases/hog.immortal.hedgehogs_hogeyes.yaml
+++ b/config/crd/bases/hog.immortal.hedgehogs_hogeyes.yaml
@@ -20,13 +20,13 @@ spec:
       name: Status
       type: string
     - jsonPath: .spec.queryResources
-      name: Resource Type
+      name: Resource_Type
       type: string
     - jsonPath: .spec.queryNamespace
-      name: Observed Namespace
+      name: Observed_Namespace
       type: string
     - jsonPath: .spec.ageThreshold
-      name: Age Threshold
+      name: Age_Threshold
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age

--- a/config/crd/bases/hog.immortal.hedgehogs_hogeyes.yaml
+++ b/config/crd/bases/hog.immortal.hedgehogs_hogeyes.yaml
@@ -53,6 +53,9 @@ spec:
             type: object
           status:
             description: HogEyeStatus defines the observed state of HogEye
+            properties:
+              status:
+                type: string
             type: object
         type: object
     served: true

--- a/config/crd/bases/hog.immortal.hedgehogs_hogeyes.yaml
+++ b/config/crd/bases/hog.immortal.hedgehogs_hogeyes.yaml
@@ -14,7 +14,24 @@ spec:
     singular: hogeye
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - description: Will display one of [Watching, Redeploying, Terminating, Error]
+      jsonPath: .status.status
+      name: Status
+      type: string
+    - jsonPath: .spec.queryResources
+      name: Resource Type
+      type: string
+    - jsonPath: .spec.queryNamespace
+      name: Observed Namespace
+      type: string
+    - jsonPath: .spec.ageThreshold
+      name: Age Threshold
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
     schema:
       openAPIV3Schema:
         description: HogEye is the Schema for the hogeyes API

--- a/internal/controller/hogeye_controller.go
+++ b/internal/controller/hogeye_controller.go
@@ -83,11 +83,11 @@ func (r *HogEyeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			Namespace: hogeye.Namespace,
 		}
 
-		// Check if the Job exists before attempting to create it
+		// Check if the Deployment exists before attempting to create it
 		var existingDeployment appsv1.Deployment
 		if err := r.Get(ctx, deploymentKey, &existingDeployment); err != nil {
 			if client.IgnoreNotFound(err) == nil {
-				// The Job does not exist, so create it
+				// The Deployment does not exist, so create it
 				deployment, err := r.createDeployment(*hogeye)
 				if err != nil {
 					log.Error(err, "failed to create Deployment Spec")
@@ -101,7 +101,7 @@ func (r *HogEyeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 					hogeye.Status.Status = "Watching"
 				}
 				if err := r.Status().Update(ctx, hogeye); err != nil {
-					log.Error(err, "unable to update HogEye status")
+					log.Error(err, "unable to update HogEye status 0")
 					return ctrl.Result{}, err
 				}
 				return ctrl.Result{}, nil
@@ -120,7 +120,7 @@ func (r *HogEyeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			}
 			hogeye.Status.Status = "Redeploying"
 			if err := r.Status().Update(ctx, hogeye); err != nil {
-				log.Error(err, "unable to update HogEye status")
+				log.Error(err, "unable to update HogEye status 1")
 				return ctrl.Result{}, err
 			}
 
@@ -137,10 +137,10 @@ func (r *HogEyeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 				hogeye.Status.Status = "Watching"
 			}
 			if err := r.Status().Update(ctx, hogeye); err != nil {
-				log.Error(err, "unable to update HogEye status")
+				log.Error(err, "unable to update HogEye status 2")
 				return ctrl.Result{}, err
 			}
-			log.Info("Updated")
+			//log.Info("Updated")
 			return ctrl.Result{}, nil
 
 		}
@@ -148,7 +148,7 @@ func (r *HogEyeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	} else {
 		hogeye.Status.Status = "Terminating"
 		if err := r.Status().Update(ctx, hogeye); err != nil {
-			log.Error(err, "unable to update HogEye status")
+			log.Error(err, "unable to update HogEye status 3")
 			return ctrl.Result{}, err
 		}
 		// The object is being deleted

--- a/internal/controller/hogeye_controller.go
+++ b/internal/controller/hogeye_controller.go
@@ -104,7 +104,7 @@ func (r *HogEyeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 					log.Error(err, "unable to update HogEye status 0")
 					return ctrl.Result{}, err
 				}
-				return ctrl.Result{}, nil
+				log.Info("Created")
 
 			} else {
 				// handle error
@@ -116,11 +116,6 @@ func (r *HogEyeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			if err := r.deleteExternalResources(ctx, *hogeye); err != nil {
 				// if fail to delete the external dependency here, return with error
 				// so that it can be retried
-				return ctrl.Result{}, err
-			}
-			hogeye.Status.Status = "Redeploying"
-			if err := r.Status().Update(ctx, hogeye); err != nil {
-				log.Error(err, "unable to update HogEye status 1")
 				return ctrl.Result{}, err
 			}
 
@@ -140,11 +135,8 @@ func (r *HogEyeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 				log.Error(err, "unable to update HogEye status 2")
 				return ctrl.Result{}, err
 			}
-			//log.Info("Updated")
-			return ctrl.Result{}, nil
-
+			log.Info("Updated")
 		}
-
 	} else {
 		hogeye.Status.Status = "Terminating"
 		if err := r.Status().Update(ctx, hogeye); err != nil {
@@ -168,7 +160,7 @@ func (r *HogEyeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 
 		// Stop reconciliation as the item is being deleted
-		return ctrl.Result{}, nil
+		log.Info("Deleted")
 	}
 
 	return ctrl.Result{}, nil


### PR DESCRIPTION
- Status will now display `Watching` if all is well, `Terminating` if deleting, or `Error` if something failed. 
- When the user runs `kubectl get hogeye`, the output will display the `NAME`, `STATUS`, `RESOURCE_TYPE`, `OBSERVED_NAMESPACE`, `AGE_THRESHOLD`, and `AGE`
- Added `Info` logs in the reconciler for creation and deletion, to match the already existing log for when a resource is updated.